### PR TITLE
Fix killing a killed ngrok process

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,12 @@ function runNgrok(opts, cb) {
 		return cb(new Error(info));
 	});
 
+	ngrok.on('exit', function () {
+		ngrok = null;
+		api = null;
+		tunnels = {};
+	});
+
 	ngrok.on('close', function () {
 		return emitter.emit('close');
 	});
@@ -224,9 +230,6 @@ function kill(cb) {
 		return cb();
 	}
 	ngrok.on('exit', function() {
-		ngrok = null;
-		api = null;
-		tunnels = {};
 		emitter.emit('disconnect');
 		return cb();
 	});


### PR DESCRIPTION
If the ngrok process has been killed by another process, a call to `ngrok.kill()` hangs indefinitely (never calling the callback).

Fix this by always binding the event handler to perform cleanup when the child process exits. `ngrok.kill()` already does check if the child process is `null` and calls the callback immediately, when that's the case.

**Test plan**

* Run an app using ngrok (XDE in my case).
* Run `killall ngrok`.
* `ngrok.kill()` call in the program should not stall the app. (Tested in debugger.)
