### PR TITLE
Replace Equinox.io usage with ngrok

### DIFF
--- a/download.js
+++ b/download.js
@@ -31,7 +31,7 @@ function downloadNgrok(callback, options) {
     const arch =
       options.arch || process.env.NGROK_ARCH || os.platform() + os.arch();
     const cdn =
-      options.cdnUrl || process.env.NGROK_CDN_URL || "https://bin.equinox.io";
+      options.cdnUrl || process.env.NGROK_CDN_URL || "https://bin.ngrok.com";
     const cdnPath =
       options.cdnPath ||
       process.env.NGROK_CDN_PATH ||

--- a/scripts/update-ngrok.sh
+++ b/scripts/update-ngrok.sh
@@ -13,7 +13,7 @@ do
   ngrok_platform=${ngrok_platform/sunos/solaris}
   ngrok_platform=${ngrok_platform/win32/windows}
   filename="ngrok-v3-stable-$ngrok_platform.zip"
-  curl -O https://bin.equinox.io/c/4VmDzA7iaHb/$filename
+  curl -O https://bin.ngrok.com/c/4VmDzA7iaHb/$filename
   unzip -o $filename
   rm $filename
   cd -


### PR DESCRIPTION
ngrok is moving away from equinox.io and to hosting packages on our own domain. This changes updates the URL.